### PR TITLE
fix: wrong project IDs for tests

### DIFF
--- a/gcpdiag/lint/apigee/apigee_rules_snapshot_test.py
+++ b/gcpdiag/lint/apigee/apigee_rules_snapshot_test.py
@@ -21,7 +21,7 @@ from gcpdiag import lint, models
 from gcpdiag.lint import apigee, report_terminal
 from gcpdiag.queries import apis_stub
 
-DUMMY_PROJECT_NAME = 'gcpdiag-gke1-aaaa'
+DUMMY_PROJECT_NAME = 'gcpd-apigee-1-lus4'
 
 
 @mock.patch('gcpdiag.queries.apis.get_api', new=apis_stub.get_api_stub)

--- a/gcpdiag/lint/apigee/snapshots/WARN_2021_001.txt
+++ b/gcpdiag/lint/apigee/snapshots/WARN_2021_001.txt
@@ -1,3 +1,14 @@
 *  apigee/WARN/2021_001: Every environment group contains at least one environment.
-   (no Apigee organizations found)                                        [SKIP]
+   - organizations/gcpd-apigee-1-lus4/envgroups/gcpdiag-demo-envgroup     [FAIL]
+     No environment is attached to the environment group: gcpdiag-demo-envgroup
+     All of the requests to the hostname list below will receive 404 errors: 
+     ['gcpdiag.apigee.example.com']
+   - organizations/gcpd-apigee-1-lus4/envgroups/gcpdiag-demo-envgroup-1   [ OK ]
+
+   An environment must be a member of at least one environment group before you
+   can access resources defined within it. In other words, you must assign an
+   environment to a group before you can use it. Or you would receive 404 errors
+   while accessing every hostname in the environment group.
+
+   https://gcpdiag.dev/rules/apigee/WARN/2021_001
 

--- a/gcpdiag/lint/composer/composer_rules_snapshot_test.py
+++ b/gcpdiag/lint/composer/composer_rules_snapshot_test.py
@@ -21,7 +21,7 @@ from gcpdiag import lint, models
 from gcpdiag.lint import composer, report_terminal
 from gcpdiag.queries import apis_stub
 
-DUMMY_PROJECT_NAME = 'gcpdiag-gke1-aaaa'
+DUMMY_PROJECT_NAME = 'composer1'
 
 
 @mock.patch('gcpdiag.queries.apis.get_api', new=apis_stub.get_api_stub)

--- a/gcpdiag/lint/composer/snapshots/WARN_2021_001.txt
+++ b/gcpdiag/lint/composer/snapshots/WARN_2021_001.txt
@@ -1,3 +1,3 @@
 *  composer/WARN/2021_001: Composer environment is in RUNNING state
-   (no composer environments found)                                       [SKIP]
+   - composer1/us-central1/good                                           [ OK ]
 

--- a/gcpdiag/lint/dataproc/dataproc_rules_snapshot_test.py
+++ b/gcpdiag/lint/dataproc/dataproc_rules_snapshot_test.py
@@ -21,7 +21,7 @@ from gcpdiag import lint, models
 from gcpdiag.lint import dataproc, report_terminal
 from gcpdiag.queries import apis_stub
 
-DUMMY_PROJECT_NAME = 'gcpdiag-gke1-aaaa'
+DUMMY_PROJECT_NAME = 'dataproc1'
 
 
 @mock.patch('gcpdiag.queries.apis.get_api', new=apis_stub.get_api_stub)

--- a/gcpdiag/lint/dataproc/snapshots/BP_2021_001.txt
+++ b/gcpdiag/lint/dataproc/snapshots/BP_2021_001.txt
@@ -1,3 +1,10 @@
 *  dataproc/BP/2021_001: Check if logging is enabled : Stackdriver Logging enabled
-   (no dataproc clusters found)                                           [SKIP]
+   - dataproc1/us-central1/good                                           [ OK ]
+   - dataproc1/us-central1/test-best-practices-disabled                   [FAIL]
+   - dataproc1/us-central1/test-best-practices-enabled                    [ OK ]
+
+   Enabling stackdriver logging for your Dataproc cluster impacts the ability to
+   troubleshoot any issues that you might have.
+
+   https://gcpdiag.dev/rules/dataproc/BP/2021_001
 

--- a/gcpdiag/lint/dataproc/snapshots/WARN_2021_001.txt
+++ b/gcpdiag/lint/dataproc/snapshots/WARN_2021_001.txt
@@ -1,3 +1,5 @@
 *  dataproc/WARN/2021_001: Dataproc cluster is in RUNNING state
-   (no dataproc clusters found)                                           [SKIP]
+   - dataproc1/us-central1/good                                           [ OK ]
+   - dataproc1/us-central1/test-best-practices-disabled                   [ OK ]
+   - dataproc1/us-central1/test-best-practices-enabled                    [ OK ]
 

--- a/gcpdiag/lint/gaes/gaes_rules_snapshot_test.py
+++ b/gcpdiag/lint/gaes/gaes_rules_snapshot_test.py
@@ -21,7 +21,7 @@ from gcpdiag import lint, models
 from gcpdiag.lint import gaes, report_terminal
 from gcpdiag.queries import apis_stub
 
-DUMMY_PROJECT_NAME = 'gcpdiag-gke1-aaaa'
+DUMMY_PROJECT_NAME = 'gcpdiag-gaes1-aaaa'
 
 
 @mock.patch('gcpdiag.queries.apis.get_api', new=apis_stub.get_api_stub)

--- a/gcpdiag/lint/gaes/snapshots/WARN_2022_001.txt
+++ b/gcpdiag/lint/gaes/snapshots/WARN_2022_001.txt
@@ -1,3 +1,3 @@
 *  gaes/WARN/2022_001: App Engine Standard versions don't use deprecated runtimes.
-   (no versions found)                                                    [SKIP]
+   - gcpdiag-gaes1-aaaa/v1                                                [ OK ]
 

--- a/gcpdiag/lint/gcf/gcf_rules_snapshot_test.py
+++ b/gcpdiag/lint/gcf/gcf_rules_snapshot_test.py
@@ -21,7 +21,7 @@ from gcpdiag import lint, models
 from gcpdiag.lint import gcf, report_terminal
 from gcpdiag.queries import apis_stub
 
-DUMMY_PROJECT_NAME = 'gcpdiag-gke1-aaaa'
+DUMMY_PROJECT_NAME = 'gcpdiag-gcf1-aaaa'
 
 
 @mock.patch('gcpdiag.queries.apis.get_api', new=apis_stub.get_api_stub)

--- a/gcpdiag/lint/gcf/snapshots/WARN_2021_001.txt
+++ b/gcpdiag/lint/gcf/snapshots/WARN_2021_001.txt
@@ -1,3 +1,3 @@
 *  gcf/WARN/2021_001: Cloud Functions don't use deprecated runtimes.
-   (no functions found)                                                   [SKIP]
+   - gcpdiag-gcf1-aaaa/gcf1                                               [ OK ]
 

--- a/gcpdiag/lint/gcs/gcs_rules_snapshot_test.py
+++ b/gcpdiag/lint/gcs/gcs_rules_snapshot_test.py
@@ -21,7 +21,7 @@ from gcpdiag import lint, models
 from gcpdiag.lint import gcs, report_terminal
 from gcpdiag.queries import apis_stub
 
-DUMMY_PROJECT_NAME = 'gcpdiag-gke1-aaaa'
+DUMMY_PROJECT_NAME = 'gcpdiag-gcs1-aaaa'
 
 
 @mock.patch('gcpdiag.queries.apis.get_api', new=apis_stub.get_api_stub)

--- a/gcpdiag/lint/gcs/snapshots/BP_2022_001.txt
+++ b/gcpdiag/lint/gcs/snapshots/BP_2022_001.txt
@@ -1,3 +1,12 @@
 *  gcs/BP/2022_001: Buckets are using uniform access
-   (no buckets found)                                                     [SKIP]
+   - gcpdiag-gcs1-aaaa/gcpdiag-gcs1bucket-aaaa                            [FAIL]
+     it is recommend to use uniform access on your bucket
+   - gcpdiag-gcs1-aaaa/gcpdiag-gcs1bucket-labels                          [FAIL]
+     it is recommend to use uniform access on your bucket
+
+   Google recommends using uniform access for a Cloud Storage bucket IAM policy
+   https://cloud.google.com/storage/docs/access-
+   control#choose_between_uniform_and_fine-grained_access
+
+   https://gcpdiag.dev/rules/gcs/BP/2022_001
 


### PR DESCRIPTION
All rules were tested using the same project ID:'gcpdiag-gke1-aaaa'. The tests skipped i.e no resources were found. I modified project IDs in the tests correspondingly.