### PR TITLE
Add shared VPC property to GKE model

### DIFF
--- a/gcpdiag/lint/gke/err_2022_002_private_google_access.py
+++ b/gcpdiag/lint/gke/err_2022_002_private_google_access.py
@@ -25,7 +25,8 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
   if not clusters:
     report.add_skipped(None, 'no clusters found')
   for _, c in sorted(clusters.items()):
-    if c.is_private and not c.subnetwork.is_private_ip_google_access():
+    if c.is_private and not c.subnetwork.is_private_ip_google_access(
+    ) and not c.is_shared_vpc:
 
       router = network.get_router(project_id=context.project_id,
                                   region=c.subnetwork.region,

--- a/gcpdiag/queries/gke.py
+++ b/gcpdiag/queries/gke.py
@@ -324,6 +324,15 @@ class Cluster(models.Resource):
     return network.get_subnetwork(m.group(1), m.group(2), m.group(3))
 
   @property
+  def is_shared_vpc(self) -> bool:
+    # projects/gcpdiag-gke1-aaaa/global/networks/default
+    network_string = self._resource_data['networkConfig']['network']
+    m = re.match(r'projects/([^/]+)/global/networks/([^/]+)$', network_string)
+    if not m:
+      raise RuntimeError("can't parse network string: %s" % network_string)
+    return self.project_id != m.group(1)
+
+  @property
   def is_private(self) -> bool:
     return 'privateClusterConfig' in self._resource_data
 


### PR DESCRIPTION
And update `private_google_access` GKE test to take a shared VPC scenario into consideration.

Currently this fails for a private cluster deployed in a shared VPC (if the VPC is not in the same project):
```
🔎 gke/ERR/2022_002: GKE nodes of private clusters can access Google APIs and services.
   - foo-bar/europe-west4/foo                    [FAIL]
      subnet bar has Private Google Access disabled and Cloud NAT is not available

   Private GKE clusters must have Private Google Access enabled on the subnet
   where cluster is deployed.

   https://gcpdiag.dev/rules/gke/ERR/2022_002
```