### PR TITLE
Account for shared VPC in `gke/err_2022_002`

### DIFF
--- a/gcpdiag/lint/gke/err_2022_002_private_google_access.py
+++ b/gcpdiag/lint/gke/err_2022_002_private_google_access.py
@@ -25,9 +25,14 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
   if not clusters:
     report.add_skipped(None, 'no clusters found')
   for _, c in sorted(clusters.items()):
+    # fetch project number
+    p: str = c.project_id
+    if c.project_id != c.network.project_id:
+      # shared vpc
+      p = c.network.project_id
     if c.is_private and not c.subnetwork.is_private_ip_google_access():
 
-      router = network.get_router(project_id=context.project_id,
+      router = network.get_router(project_id=p,
                                   region=c.subnetwork.region,
                                   network=c.network)
 


### PR DESCRIPTION
If the network is in a shared VPC, get the router from the shared vpc project instead.

Fixes https://github.com/GoogleCloudPlatform/gcpdiag/issues/23