### PR TITLE
Fix os version detection on err_2022_002_image_versions

### DIFF
--- a/gcpdiag/lint/dataproc/err_2022_002_image_versions.py
+++ b/gcpdiag/lint/dataproc/err_2022_002_image_versions.py
@@ -75,9 +75,9 @@ class ImageVersion:
     if self.version.major == 1 and self.version.minor < 4:
       return True
     if self.version.major == 1 and 4 <= self.version.minor <= 5:
-      if self.version.os == 'debian' and self.os_ver < 10:
+      if self.version.os == 'debian' and self.version.os_ver < 10:
         return True
-      if self.version.os == 'ubuntu' and self.os_ver < 18:
+      if self.version.os == 'ubuntu' and self.version.os_ver < 18:
         return True
     return False
 


### PR DESCRIPTION
This PR fix the following issue

```python
Traceback (most recent call last):
  File "/gcpdiag/bin/gcpdiag", line 64, in <module>
    main(sys.argv)
  File "/gcpdiag/bin/gcpdiag", line 42, in main
    lint_command.run(argv)
  File "/gcpdiag/gcpdiag/lint/command.py", line 267, in run
    exit_code = repo.run_rules(context, report, include_patterns,
  File "/gcpdiag/gcpdiag/lint/__init__.py", line 430, in run_rules
    rule.run_rule_f(context, rule_report)
  File "/gcpdiag/gcpdiag/lint/dataproc/err_2022_002_image_versions.py", line 96, in run_rule
    if ImageVersion(cluster.image_version).is_deprecated():
  File "/gcpdiag/gcpdiag/lint/dataproc/err_2022_002_image_versions.py", line 78, in is_deprecated
    if self.version.os == 'debian' and self.os_ver < 10:
AttributeError: 'ImageVersion' object has no attribute 'os_ver'
```