### PR TITLE
gke/ERR/2021_002: Add missing early return

### DIFF
--- a/gcpdiag/lint/gke/err_2021_007_gke_sa.py
+++ b/gcpdiag/lint/gke/err_2021_007_gke_sa.py
@@ -28,6 +28,7 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
   clusters = gke.get_clusters(context)
   if not clusters:
     report.add_skipped(None, 'no clusters found')
+    return
 
   project = crm.get_project(context.project_id)
   sa = 'service-{}@container-engine-robot.iam.gserviceaccount.com'.format(


### PR DESCRIPTION
Otherwise the rule runs (and fails) even if there are no clusters