### PR TITLE
Solution for issue #47-uniform bucket-level access is recommended

### DIFF
--- a/gcpdiag/queries/gcs.py
+++ b/gcpdiag/queries/gcs.py
@@ -71,7 +71,7 @@ class Bucket(models.Resource):
   def is_uniform_access(self) -> bool:
     return get_path(self._resource_data,
                     ('iamConfiguration', 'uniformBucketLevelAccess', 'enabled'),
-                    default=False) == {}
+                    default=False)
 
   @property
   def full_path(self) -> str:


### PR DESCRIPTION
In gcs.py file is_uniform_access function was returning a empty dictionary {} always. If that it removed only the required boolean value will be returned