### PR TITLE
Fix wrong cloudsql/WARN/2023_003 MQL query

### DIFF
--- a/gcpdiag/lint/cloudsql/bp_ext_2023_003_auto_storage_increases.py
+++ b/gcpdiag/lint/cloudsql/bp_ext_2023_003_auto_storage_increases.py
@@ -15,7 +15,7 @@
 # Lint as: python3
 """Cloud SQL enables automatic storage increases feature
 
-Configure storage to accomodate critical database maintennance by enabling the
+Configure storage to accommodate critical database maintenance by enabling the
 automatic storage increases feature. Otherwise, ensure that you have at least
 20% available space to accommodate any critical database maintenance operations
 that Cloud SQL may perform. Keep in mind that when an instance becomes unable to

--- a/gcpdiag/lint/cloudsql/warn_2023_003_high_mem_usage.py
+++ b/gcpdiag/lint/cloudsql/warn_2023_003_high_mem_usage.py
@@ -43,12 +43,12 @@ def prefetch_rule(context: models.Context):
       context.project_id,
       f"""
       fetch cloudsql_database
-       | metric 'cloudsql.googleapis.com/database/memory/components'
-       | group_by 6h, [value_components_aggregate: aggregate(value.components)]
-       | filter metric.component = 'Usage'
-       | every 6h
-       | filter val() >= {MEM_USAGE_THRESHOLD}
-       | {within_str}
+        | metric 'cloudsql.googleapis.com/database/memory/components'
+        | group_by 6h, [value_components_max: max(value.components)]
+        | filter metric.component = 'Usage'
+        | every 6h
+        | filter val() >= {MEM_USAGE_THRESHOLD}
+        | {within_str}
       """)
 
 


### PR DESCRIPTION
This changes the MQL query for cloudsql/WARN/2023_003 from `aggregate` (which adds the value up to the thousands) to `max` which I assume was the intended way this query works.


Also, I fixed two small typos I found when I accidentally opened the wrong file.

Edit: Fixes #74 