### PR TITLE
new rule: GKE Metadata Server isn't reporting errors for pod IP not found

### DIFF
--- a/gcpdiag/lint/gke/err_2023_011_wi_pod_ip_not_found.py
+++ b/gcpdiag/lint/gke/err_2023_011_wi_pod_ip_not_found.py
@@ -20,7 +20,7 @@ a misconfiguration or a workload that is not compatible with GKE Workload Identi
 
 from gcpdiag import lint, models
 from gcpdiag.lint.gke import util
-from gcpdiag.queries import gke, gce, crm, logs
+from gcpdiag.queries import crm, gce, gke, logs
 
 GKE_METADATA_SERVER_CONTAINER_NAME = 'gke-metadata-server'
 MATCH_STR = 'Unable to find pod: generic::not_found: retry budget exhausted'
@@ -29,10 +29,14 @@ MATCH_STR_END = 'not recorded in the snapshot'
 # https://cloud.google.com/container-optimized-os/docs/how-to/logging
 GCE_METADATA_COS_LOGGING_ENABLED = 'google-logging-enabled'
 GCE_METADATA_COS_FLUENT_BIT = 'google-logging-use-fluentbit'
-COS_LEGACY_AGENT_WARNING = 'Project metadata contains google-logging-enabled=true but not google-logging-use-fluentbit=true\nCOS VMs before Milestone 109 will use the deprecated legacy logging agent, which is not compatible with GKE Workload Identity. See https://cloud.google.com/container-optimized-os/docs/how-to/logging'
+COS_LEGACY_AGENT_WARNING = """Project metadata contains google-logging-enabled=true but not
+google-logging-use-fluentbit=true. COS VMs before Milestone 109 will use the deprecated
+legacy logging agent, which is not compatible with GKE Workload Identity.
+See https://cloud.google.com/container-optimized-os/docs/how-to/logging"""
 
 # k8s_container
 metadata_server_errors = {}
+
 
 def prepare_rule(context: models.Context):
   metadata_server_errors[context.project_id] = logs.query(
@@ -53,12 +57,14 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
   project_metadata = gce.get_project_metadata(context.project_id)
   if project_metadata.get(GCE_METADATA_COS_LOGGING_ENABLED) == 'true' and \
     not project_metadata.get(GCE_METADATA_COS_FLUENT_BIT) == 'true':
-    report.add_failed(crm.get_project(context.project_id), COS_LEGACY_AGENT_WARNING)
+    report.add_failed(crm.get_project(context.project_id),
+                      COS_LEGACY_AGENT_WARNING)
 
   # Search the logs.
   def filter_f(log_entry):
     try:
-      if log_entry['jsonPayload']['message'].endswith(MATCH_STR_END) and MATCH_STR in log_entry['jsonPayload']['message']:
+      if log_entry['jsonPayload']['message'].endswith(
+          MATCH_STR_END) and MATCH_STR in log_entry['jsonPayload']['message']:
         return True
     except KeyError:
       return False

--- a/gcpdiag/lint/gke/err_2023_011_wi_pod_ip_not_found.py
+++ b/gcpdiag/lint/gke/err_2023_011_wi_pod_ip_not_found.py
@@ -1,0 +1,77 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GKE Metadata Server isn't reporting errors for pod IP not found.
+
+The gke-metadata-server DaemonSet uses pod IP addresses to match client
+requests to Kubernetes Service Accounts. Pod IP not found errors may indicate
+a misconfiguration or a workload that is not compatible with GKE Workload Identity.
+"""
+
+from gcpdiag import lint, models
+from gcpdiag.lint.gke import util
+from gcpdiag.queries import gke, gce, crm, logs
+
+GKE_METADATA_SERVER_CONTAINER_NAME = 'gke-metadata-server'
+MATCH_STR = 'Unable to find pod: generic::not_found: retry budget exhausted'
+MATCH_STR_END = 'not recorded in the snapshot'
+
+# https://cloud.google.com/container-optimized-os/docs/how-to/logging
+GCE_METADATA_COS_LOGGING_ENABLED = 'google-logging-enabled'
+GCE_METADATA_COS_FLUENT_BIT = 'google-logging-use-fluentbit'
+COS_LEGACY_AGENT_WARNING = 'Project metadata contains google-logging-enabled=true but not google-logging-use-fluentbit=true\nCOS VMs before Milestone 109 will use the deprecated legacy logging agent, which is not compatible with GKE Workload Identity. See https://cloud.google.com/container-optimized-os/docs/how-to/logging'
+
+# k8s_container
+metadata_server_errors = {}
+
+def prepare_rule(context: models.Context):
+  metadata_server_errors[context.project_id] = logs.query(
+      project_id=context.project_id,
+      resource_type='k8s_container',
+      log_name='log_id("stderr")',
+      filter_str='severity=ERROR AND '+\
+      f'resource.labels.container_name="{GKE_METADATA_SERVER_CONTAINER_NAME}"')
+
+
+def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
+  clusters = gke.get_clusters(context)
+  if not clusters:
+    report.add_skipped(None, 'no clusters found')
+    return
+
+  # Check if GCP Project metadata is configured for legacy agent or fluent-bit
+  project_metadata = gce.get_project_metadata(context.project_id)
+  if project_metadata.get(GCE_METADATA_COS_LOGGING_ENABLED) == 'true' and \
+    not project_metadata.get(GCE_METADATA_COS_FLUENT_BIT) == 'true':
+    report.add_failed(crm.get_project(context.project_id), COS_LEGACY_AGENT_WARNING)
+
+  # Search the logs.
+  def filter_f(log_entry):
+    try:
+      if log_entry['jsonPayload']['message'].endswith(MATCH_STR_END) and MATCH_STR in log_entry['jsonPayload']['message']:
+        return True
+    except KeyError:
+      return False
+
+  clusters_with_errors = util.gke_logs_find_bad_clusters(
+      context=context,
+      logs_by_project=metadata_server_errors,
+      filter_f=filter_f)
+
+  for _, c in sorted(clusters.items()):
+    if not c.has_workload_identity_enabled():
+      report.add_skipped(c, 'GKE Workload Identity is disabled')
+    elif c in clusters_with_errors:
+      report.add_failed(c, logs.format_log_entry(clusters_with_errors[c]))
+    else:
+      report.add_ok(c)

--- a/gcpdiag/lint/gke/snapshots/ERR_2023_011.txt
+++ b/gcpdiag/lint/gke/snapshots/ERR_2023_011.txt
@@ -1,0 +1,12 @@
+*  gke/ERR/2023_011: GKE Metadata Server isn't reporting errors for pod IP not found.
+   - gcpdiag-gke1-aaaa/europe-west4/autopilot-gke1                        [ OK ]
+   - gcpdiag-gke1-aaaa/europe-west4/autopilot-gke2                        [ OK ]
+   - gcpdiag-gke1-aaaa/europe-west4/gke2                                  [ OK ]
+   - gcpdiag-gke1-aaaa/europe-west4/gke3                                  [SKIP]
+     GKE Workload Identity is disabled
+   - gcpdiag-gke1-aaaa/europe-west4-a/gke1                                [SKIP]
+     GKE Workload Identity is disabled
+   - gcpdiag-gke1-aaaa/europe-west4-a/gke4                                [ OK ]
+   - gcpdiag-gke1-aaaa/europe-west4-a/gke6                                [SKIP]
+     GKE Workload Identity is disabled
+

--- a/website/content/en/docs/development/architecture.md
+++ b/website/content/en/docs/development/architecture.md
@@ -166,7 +166,7 @@ modules instead. This ensures proper testing and separation of concerns. Also,
 this way we can make sure that the queries modules cover all the required
 functionality, and that the API calls are cached.
 
-You can see the documentation of this rule [here](https://gcpdiag.dev/rules/gke/ERR/2021_007/) and the github logic for this rule [here](https://github.com/444B/gcpdiag/blob/main/gcpdiag/lint/gke/err_2021_007_gke_sa.py)
+You can see the documentation of this rule [here](https://gcpdiag.dev/rules/gke/ERR/2021_007/) and the github logic for this rule [here](https://github.com/GoogleCloudPlatform/gcpdiag/blob/main/gcpdiag/lint/gke/err_2021_007_gke_sa.py)
 
 Example code:
 ```python

--- a/website/content/en/rules/gke/ERR/2023_011.md
+++ b/website/content/en/rules/gke/ERR/2023_011.md
@@ -1,0 +1,46 @@
+---
+title: "gke/ERR/2023_011"
+linkTitle: "ERR/2023_011"
+weight: 1
+type: docs
+description: >
+  GKE Metadata Server isn't reporting errors for pod IP not found
+---
+
+**Product**: [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)\
+**Rule class**: ERR - Something that is very likely to be wrong
+
+### Description
+
+The gke-metadata-server DaemonSet uses pod IP addresses to match client
+requests to Kubernetes Service Accounts. Pod IP not found errors may indicate
+a misconfiguration or a workload that is not compatible with GKE Workload Identity.
+
+You can use the following Cloud Logging filter to find errors in the GKE Metadata Server logs:
+
+```
+resource.type="k8s_container"
+log_id("stderr")
+resource.labels.container_name="gke-metadata-server"
+severity=ERROR
+```
+
+Examples from **gke-metadata-server --component-version=0.4.276**:
+> [conn-id:bc54e859ac0e7269] Unable to find pod: generic::not_found: retry budget exhausted (50 attempts): ip "169.254.123.2" not recorded in the snapshot
+>
+> [conn-id:bc54e859ac0e7269 rpc-id:29b6f8cbdbdaafb5] Caller is not authenticated
+
+Older example from **gke-metadata-server --component-version=0.4.275**:
+> [ip:172.17.0.2 pod:/ rpc-id:387a551d4b506f31] Failed to find Workload Identity configuration for pod: while retrieving pod from cache: pod "" not found
+
+Note: **172.17.0.0/16** and **169.254.123.0/24** are the default ranges used by the Docker daemon for container networking.
+
+### Remediation
+
+One known cause of these errors is use of the deprecated legacy logging agent on [COS GKE Nodes](https://cloud.google.com/container-optimized-os/docs/how-to/logging) via project metadata `google-logging-enabled=true` without `google-logging-use-fluentbit=true` which was introduced in COS Milestone 105. Enabling the fluent-bit agent will automatically update all existing nodes and prevent them from generating pod not found error messages. In [COS Milestone 109](https://cloud.google.com/container-optimized-os/docs/concepts/versioning) the fluent-bit agent will become the default when enabling logging via project metadata.
+
+Another cause could be docker-in-docker pods (often used by CI/CD systems to build containers) running with `hostNetwork: true` or other docker based VM agents running outside Kubernetes. If you identify a workload that is not compatible with the GKE Metadata Server, you can [create a nodepool](https://cloud.google.com/sdk/gcloud/reference/container/node-pools/create#--workload-metadata) with `--workload-metadata=GCE_METADATA` and use [taints/tolerations](https://cloud.google.com/kubernetes-engine/docs/how-to/node-taints) to specify where the workload should run.
+
+### Further information
+
+See [Workload Identity docs](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) for more restrictions and alternatives.


### PR DESCRIPTION
This adds a new rule for a tricky gke-metadata-server error log. We recently found the GCP Project Metadata for [enabling COS logging](https://cloud.google.com/container-optimized-os/docs/how-to/logging) will default to the legacy logging agent unless you add `google-logging-use-fluentbit=true`. The legacy agent is deployed via cloud-init and uses the Docker daemon, which runs the containers with IPs from 172.17.0.0/16 or 169.254.123.0/24 range. Those address ranges cause errors to appear in the gke-metadata-server logs and in some instances can cause other issues (More details at b/295924074).

This rule is designed to detect GKE clusters with those error messages and also detect projects with the known issue (COS Nodes using legacy logging agent). In Milestone 109 COS will default to the fluent-bit agent, so in the future the metadata logic could be removed. But there could always be a docker-in-docker or manually configured process that uses non-pod-cidr IPs. Here is an example of the current output for a GKE cluster with Workload Identity, COS_CONTAINERD nodes, and the incompatible legacy agent installed via project metadata:

![2023-08-21_19-14](https://github.com/GoogleCloudPlatform/gcpdiag/assets/304401/2ff44821-7be6-4fa9-901b-6d83c9d3c37d)


