### PR TITLE
Account for GKE zones in vpc/WARN/2023_002

### DIFF
--- a/gcpdiag/queries/network.py
+++ b/gcpdiag/queries/network.py
@@ -174,7 +174,10 @@ class ManagedZone(models.Resource):
     if 'privateVisibilityConfig' not in self._resource_data:
       self._resource_data['privateVisibilityConfig'] = {}
 
-    return self._resource_data['privateVisibilityConfig'].get('networks', False)
+    return (self._resource_data['privateVisibilityConfig'].get(
+        'networks', False) or
+            self._resource_data['privateVisibilityConfig'].get(
+                'gkeClusters', False))
 
   @property
   def dnssec_config_state(self) -> bool:


### PR DESCRIPTION
[vpc/WARN/2023_002](https://gcpdiag.dev/rules/vpc/WARN/2023_002/) fails for Cloud DNS zones that are used for [GKE clusters](https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns).

This is supported in the [API](https://cloud.google.com/dns/docs/reference/v1/managedZones#:~:text=%5D%2C%0A%C2%A0%20%C2%A0%20%22-,gkeClusters,-%22%3A%20%5B), and should prevent failures in [those scenarios](https://github.com/GoogleCloudPlatform/gcpdiag/blob/main/gcpdiag/lint/vpc/warn_2023_002_private_zone_attachment.py#L29-L30).