### PR TITLE
Updating working and typos in multiple files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 				"python.defaultInterpreterPath": "/usr/local/bin/python",
 				"python.linting.enabled": true,
 				"python.linting.pylintEnabled": true,
-				"python.envFile": "${workspaceFolder}/.devcontainer/.env" // Forcing some specific env settings for debugging any dynmaic python file - normal env vars are not correctly picked up
+				"python.envFile": "${workspaceFolder}/.devcontainer/.env" // Forcing some specific env settings for debugging any dynamic python file - normal env vars are not correctly picked up
 			},
 			"extensions": [
 				"ms-python.python",
@@ -27,7 +27,7 @@
 	"onCreateCommand": "PATH=$HOME/.local/bin:$PATH && pipenv install --dev", // We need to execute the commands very early to allow VS Code (-extensions) to correctly pick up the pipenv venv
 	"postCreateCommand": "pipenv run pre-commit install",
 	"remoteUser": "root",
-	// Podman specfic settings
+	// Podman specific settings
 	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,Z",
 	"workspaceFolder": "/workspace",
 	//"runArgs": [

--- a/.pylintrc
+++ b/.pylintrc
@@ -279,7 +279,7 @@ single-line-if-stmt=yes
 max-module-lines=99999
 
 # String used as indentation unit.  The internal Google style guide mandates 2
-# spaces.  Google's externaly-published style guide says 4, consistent with
+# spaces.  Google's externally-published style guide says 4, consistent with
 # PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
 # projects (like TensorFlow).
 indent-string='  '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,8 +141,8 @@
 - notebooks/ERR/2023\_003: Vertex AI Workbench account has permissions to create and use notebooks
 - notebooks/ERR/2023\_004: Vertex AI Workbench runtimes for managed notebooks are healthy
 - notebooks/WARN/2023\_001: Vertex AI Workbench instance is not being OOMKilled
-- notebooks/WARN/2023\_002: Vertex AI Workbench instance is in healty data disk space status
-- notebooks/WARN/2023\_003: Vertex AI Workbench instance is in healty boot disk space status
+- notebooks/WARN/2023\_002: Vertex AI Workbench instance is in healthy data disk space status
+- notebooks/WARN/2023\_003: Vertex AI Workbench instance is in healthy boot disk space status
 - vpc/SEC/2023\_001: DNSSEC is enabled for public zones
 - vpc/WARN/2023\_002: Private zone is attached to a VPC
 
@@ -296,7 +296,7 @@
 - bigquery/ERR/2022\_004: BigQuery jobs are not failing due to shuffle operation resources exceeded
 - bigquery/WARN/2022\_002: BigQuery does not violate column level security
 - cloudsql/WARN/2022\_001: Docker bridge network should be avoided
-- composer/WARN/2022\_002: fluentd pods in Composer enviroments are not crashing
+- composer/WARN/2022\_002: fluentd pods in Composer environments are not crashing
 - dataproc/ERR/2022\_003: Dataproc Service Account permissions
 - dataproc/WARN/2022\_001: Dataproc clusters are not failed to stop due to the local SSDs
 - gae/WARN/2022\_002: App Engine Flexible versions don't use deprecated runtimes

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The authenticated principal will need as minimum the following roles granted (bo
 
 - `Viewer` on the inspected project
 - `Service Usage Consumer` on the project used for billing/quota enforcement,
-  which is per default the project being inspected, but can be explicitely set
+  which is per default the project being inspected, but can be explicitly set
   using the `--billing-project` option
 
 The Editor and Owner roles include all the required permissions, but if you use

--- a/bin/gcpdiag-dockerized
+++ b/bin/gcpdiag-dockerized
@@ -27,7 +27,7 @@ version_ge () {
 }
 
 # Test whether 1st arg (file) was provided and exists, then prepare mount path
-# that will be used inside container with the same path if absolut path was used
+# that will be used inside container with the same path if absolute path was used
 # or inside root folder if relative path was used.
 handle_mount_path () {
   local FILE="$1"
@@ -35,7 +35,7 @@ handle_mount_path () {
   if [ -n "$FILE" ]; then
     if [ -f "$FILE" ]; then
       if [[ "$FILE" = /* ]]; then
-        # absolut path shall be mounted as is
+        # absolute path shall be mounted as is
         MOUNT="-v $FILE:$FILE"
       else
         # local path need to be mounted inside root folder
@@ -112,7 +112,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # If config argument was provided we need to check if file exists and mount it
-# inside container with the same path if absolut path was used or inside
+# inside container with the same path if absolute path was used or inside
 # root folder if relative path was used.
 if ! CONFIG_MOUNT=$(handle_mount_path "$CONFIG_FILE"); then
     echo
@@ -123,7 +123,7 @@ if ! CONFIG_MOUNT=$(handle_mount_path "$CONFIG_FILE"); then
 fi
 
 # If auth-key argument was provided we need to check if file exists and mount it
-# inside container with the same path if absolut path was used or inside
+# inside container with the same path if absolute path was used or inside
 # root folder if relative path was used.
 if ! AUTH_KEY_MOUNT=$(handle_mount_path "$AUTH_KEY"); then
     echo

--- a/gcpdiag/async_queries/api/default_random.py
+++ b/gcpdiag/async_queries/api/default_random.py
@@ -1,9 +1,9 @@
-""" Generate random numbers betwee 0 and 1 """
+""" Generate random numbers between 0 and 1 """
 import random
 
 
 class Random:
-  """ Generate random numbers betwee 0 and 1 """
+  """ Generate random numbers between 0 and 1 """
 
   def generate(self) -> float:
     return random.random()

--- a/gcpdiag/async_queries/api/test_webserver.py
+++ b/gcpdiag/async_queries/api/test_webserver.py
@@ -11,7 +11,7 @@ class Response(Protocol):
 
 
 class Success:
-  """ Canned successfull response """
+  """ Canned successful response """
 
   def __init__(self, data: Any) -> None:
     self.data = data

--- a/gcpdiag/async_queries/dataproc/dataproc.py
+++ b/gcpdiag/async_queries/dataproc/dataproc.py
@@ -8,7 +8,7 @@ from gcpdiag.queries import dataproc
 
 
 class Region:
-  """ Helper class encapsulating Dataproc operations withing a region """
+  """ Helper class encapsulating Dataproc operations within a region """
   _api: protocols.API
   _project_id: str
   _region: str

--- a/gcpdiag/async_queries/project/project.py
+++ b/gcpdiag/async_queries/project/project.py
@@ -1,4 +1,4 @@
-""" Class representing different services avaiable within a GCP project """
+""" Class representing different services available within a GCP project """
 import functools
 
 from gcpdiag.async_queries import project_regions
@@ -7,7 +7,7 @@ from gcpdiag.async_queries.utils import protocols
 
 
 class Project:
-  """ Class representing different services avaiable within a GCP project """
+  """ Class representing different services available within a GCP project """
   _project_id: str
   _api: protocols.API
 

--- a/gcpdiag/async_queries/utils/loader.py
+++ b/gcpdiag/async_queries/utils/loader.py
@@ -32,7 +32,7 @@ class Loader:
 
     In this case, it doesn't matter how many clients call
     my_gateway.get_response() concurrently, expensive_api_call() only executed
-    once (and all clients recive results of this call)
+    once (and all clients receive results of this call)
   """
   _load_task: Optional[asyncio.Task]
   _load_coroutine: Optional[Callable[[], Coroutine]]

--- a/gcpdiag/config_test.py
+++ b/gcpdiag/config_test.py
@@ -124,7 +124,7 @@ class Test:
       # load config from file
       config.init({'config': fp.name})
       assert config.get('config') == fp.name
-      # read value availale only from config
+      # read value available only from config
       assert config.get('logging_ratelimit_requests') == 60
       assert config.get('logging_fetch_max_time_seconds') == 120
 

--- a/gcpdiag/lint/__init__.py
+++ b/gcpdiag/lint/__init__.py
@@ -148,7 +148,7 @@ class LintReportRuleInterface:
 class LintResultsHandler(Protocol):
   """
   Protocol representing object capable of handling lint results (handlers).
-  Hanlders can be registered with LintResults and react on each rule added
+  Handlers can be registered with LintResults and react on each rule added
   to the LintResults: each time a rule is added to the LintResults
   process_rule_report method of each registered handler is called with
   LintReportRuleInterface, so that handler have access to the results of
@@ -170,7 +170,7 @@ class LintResults:
 
   def add_result_handler(self, handler: LintResultsHandler) -> None:
     """
-    Hanlders can be registered with LintResults and react on each rule added
+    Handlers can be registered with LintResults and react on each rule added
     to the LintResults: each time a rule is added to theLintResults
     process_rule_report method of each registered handler is called with
     LintReportRuleInterface, so that handler have access to the results of
@@ -304,7 +304,7 @@ class ExecutionStrategy(Protocol):
 
 class SequentialExecutionStrategy:
   """
-  Execution strategy that groups multiple execution strageties
+  Execution strategy that groups multiple execution strategies
   and runs them sequentially one after another.
   """
   strategies: List[ExecutionStrategy]
@@ -562,7 +562,7 @@ class SyncExecutionStrategy:
     # Start fetching any logs queries that were defined in prepare_rule
     # functions.
     logs.execute_queries(executor)
-    # Start fetching any serial output logs if serial ouput to cloud logging
+    # Start fetching any serial output logs if serial output to cloud logging
     # is not enabled on the project/ instance
     if config.get('enable_gce_serial_buffer'):
       # execute fetech job

--- a/gcpdiag/lint/bigquery/err_2023_003_resource_exceeded.py
+++ b/gcpdiag/lint/bigquery/err_2023_003_resource_exceeded.py
@@ -15,7 +15,7 @@
 # Lint as: python3
 """BigQuery query job do not encounter resource exceeded error
 
-A BigQuery query sometimes could not be executed in the alloted memory
+A BigQuery query sometimes could not be executed in the allotted memory
 """
 
 from boltons.iterutils import get_path

--- a/gcpdiag/lint/command.py
+++ b/gcpdiag/lint/command.py
@@ -304,7 +304,7 @@ def run(argv) -> int:
   # ^^^ If you add rules directory, update also
   # pyinstaller/hook-gcpdiag.lint.py and bin/precommit-required-files
 
-  # Initialize proper output formater
+  # Initialize proper output formatter
   output_order = sorted(str(r) for r in repo.rules_to_run)
   output = _initialize_output(output_order=output_order)
   repo.result.add_result_handler(output.result_handler)

--- a/gcpdiag/lint/composer/err_2023_001_composer_not_in_error_state.py
+++ b/gcpdiag/lint/composer/err_2023_001_composer_not_in_error_state.py
@@ -15,7 +15,7 @@
 
 The ERROR state indicates that the environment has encountered an error and
 cannot be used. Creating/updateing environment through misconfigured Terraform
-config, errors in PyPI Pacakge or etc could be the cause of the issue.
+config, errors in PyPI Package or etc could be the cause of the issue.
 """
 
 from gcpdiag import lint, models

--- a/gcpdiag/lint/composer/snapshots/WARN_2022_002.txt
+++ b/gcpdiag/lint/composer/snapshots/WARN_2022_002.txt
@@ -1,4 +1,4 @@
-*  composer/WARN/2022_002: fluentd pods in Composer enviroments are not crashing
+*  composer/WARN/2022_002: fluentd pods in Composer environments are not crashing
    - gcpdiag-composer1-aaaa/us-central1/env2                              [ OK ]
    - gcpdiag-composer1-aaaa/us-central1/env1                              [ OK ]
 

--- a/gcpdiag/lint/composer/warn_2022_002_fluentd_pod_crashloop.py
+++ b/gcpdiag/lint/composer/warn_2022_002_fluentd_pod_crashloop.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Lint as: python3
-"""fluentd pods in Composer enviroments are not crashing
+"""fluentd pods in Composer environments are not crashing
 
 The fluentd runs as a daemonset and collects logs from all environment
 components and uploads the logs to Cloud Logging. All fluentd pods in an

--- a/gcpdiag/lint/dataproc/err_2023_007_cluster_creation_stockout.py
+++ b/gcpdiag/lint/dataproc/err_2023_007_cluster_creation_stockout.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Lint as: python3
-"""Region has sufficent resources for user to create a cluster
+"""Region has sufficient resources for user to create a cluster
 
 Region is experiencing a resource stockout while creating the cluster. \n Kindly
-try creating the cluster in another zone or region. \n If the specifed
+try creating the cluster in another zone or region. \n If the specified
 Region/Zone is a must, please reach out to GCP support team with the \n previous
 details provided.
 """

--- a/gcpdiag/lint/dataproc/snapshots/ERR_2023_007.txt
+++ b/gcpdiag/lint/dataproc/snapshots/ERR_2023_007.txt
@@ -1,4 +1,4 @@
-*  dataproc/ERR/2023_007: Region has sufficent resources for user to create a cluster
+*  dataproc/ERR/2023_007: Region has sufficient resources for user to create a cluster
    - gcpdiag-dataproc1-aaaa                                               [SKIP]
      logging api is disabled
 

--- a/gcpdiag/lint/gae/err_2023_002_appengine_vpc_connector_subnet_overlap.py
+++ b/gcpdiag/lint/gae/err_2023_002_appengine_vpc_connector_subnet_overlap.py
@@ -81,7 +81,7 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
         continue
       report.add_failed(
           project, 'There may have been a failed VPC \
-            connector creation issue on App Engine due to overlaping subnetworks \
+            connector creation issue on App Engine due to overlapping subnetworks \
               in the range 10.128.0.0/9 [auto-subnetworks]')
       return
 

--- a/gcpdiag/lint/gce/bp_2023_001_ntp_config.py
+++ b/gcpdiag/lint/gce/bp_2023_001_ntp_config.py
@@ -43,7 +43,7 @@ def prepare_rule(context: models.Context):
 
 
 def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
-  # skip entire rule if serial outputs are unavailabe
+  # skip entire rule if serial outputs are unavailable
   if not utils.is_serial_port_one_logs_available(context):
     report.add_skipped(None, 'serial port output is unavailable')
     return

--- a/gcpdiag/lint/gce/err_2021_005_mount_errors.py
+++ b/gcpdiag/lint/gce/err_2021_005_mount_errors.py
@@ -42,7 +42,7 @@ def prepare_rule(context: models.Context):
 
 
 def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
-  # skip entire rule if serial outputs are unavailabe
+  # skip entire rule if serial outputs are unavailable
   if not utils.is_serial_port_one_logs_available(context):
     report.add_skipped(None, 'serial port output is unavailable')
     return

--- a/gcpdiag/lint/gce/err_2022_002_premium_guestos_activation_failed.py
+++ b/gcpdiag/lint/gce/err_2022_002_premium_guestos_activation_failed.py
@@ -46,7 +46,7 @@ def prepare_rule(context: models.Context):
 
 
 def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
-  # skip entire rule if serial outputs are unavailabe
+  # skip entire rule if serial outputs are unavailable
   if not utils.is_serial_port_one_logs_available(context):
     report.add_skipped(None, 'serial port output is unavailable')
     return

--- a/gcpdiag/lint/gce/warn_2021_004_disk_full_serial_messages.py
+++ b/gcpdiag/lint/gce/warn_2021_004_disk_full_serial_messages.py
@@ -41,7 +41,7 @@ def prepare_rule(context: models.Context):
 
 
 def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
-  # skip entire rule if serial outputs are unavailabe
+  # skip entire rule if serial outputs are unavailable
   if not utils.is_serial_port_one_logs_available(context):
     report.add_skipped(None, 'serial port output is unavailable')
     return

--- a/gcpdiag/lint/gce/warn_2021_005_out_of_memory.py
+++ b/gcpdiag/lint/gce/warn_2021_005_out_of_memory.py
@@ -43,7 +43,7 @@ def prepare_rule(context: models.Context):
 
 
 def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
-  # skip entire rule if serial outputs are unavailabe
+  # skip entire rule if serial outputs are unavailable
   if not utils.is_serial_port_one_logs_available(context):
     report.add_skipped(None, 'serial port output is unavailable')
     return

--- a/gcpdiag/lint/gce/warn_2021_006_kernel_panic.py
+++ b/gcpdiag/lint/gce/warn_2021_006_kernel_panic.py
@@ -16,7 +16,7 @@
 """Serial logs don't contain "Kernel panic" messages
 
 The "Kernel panic" messages in serial output usually indicate that some
-fatal error occured on a Linux instance.
+fatal error occurred on a Linux instance.
 """
 from typing import Optional
 
@@ -38,7 +38,7 @@ def prepare_rule(context: models.Context):
 
 
 def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
-  # skip entire rule if serial outputs are unavailabe
+  # skip entire rule if serial outputs are unavailable
   if not utils.is_serial_port_one_logs_available(context):
     report.add_skipped(None, 'serial port output is unavailable')
     return
@@ -55,7 +55,7 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
       if match:
         report.add_failed(
             instance, ('There are messages indicating that '
-                       '"Kernel panic" event occured for {}\n{}: "{}"').format(
+                       '"Kernel panic" event occurred for {}\n{}: "{}"').format(
                            instance.name, match.timestamp_iso, match.text))
       else:
         report.add_ok(instance)

--- a/gcpdiag/lint/gce/warn_2021_007_bsod.py
+++ b/gcpdiag/lint/gce/warn_2021_007_bsod.py
@@ -17,7 +17,7 @@
 
 The messages:
 "Dumping stack trace" / "pvpanic.sys" in serial output usually indicate that some
-fatal error occured on a Windows instance.
+fatal error occurred on a Windows instance.
 """
 from typing import Optional
 
@@ -40,7 +40,7 @@ def prepare_rule(context: models.Context):
 
 
 def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
-  # skip entire rule if serial outputs are unavailabe
+  # skip entire rule if serial outputs are unavailable
   if not utils.is_serial_port_one_logs_available(context):
     report.add_skipped(None, 'serial port output is unavailable')
     return
@@ -57,7 +57,7 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
       if match:
         report.add_failed(instance,
                           ('There are messages indicating that '
-                           '"BSOD" event occured for {}\n{}: "{}"').format(
+                           '"BSOD" event occurred for {}\n{}: "{}"').format(
                                instance.name, match.timestamp_iso, match.text))
       else:
         report.add_ok(instance)

--- a/gcpdiag/lint/gce/warn_2022_010_resource_availability.py
+++ b/gcpdiag/lint/gce/warn_2022_010_resource_availability.py
@@ -15,7 +15,7 @@
 # Lint as: python3
 """GCE has enough resources available to fulfill requests
 
-Resource availablity errors can occur when using GCE resource on demand and a zone
+Resource availability errors can occur when using GCE resource on demand and a zone
 cannot accommodate your request due to resource exhaustion for the specific VM configuration
 
 Consider trying your request in other zones, requesting again with

--- a/gcpdiag/lint/gke/bp_2023_001_network_policy_minimum_requirements.py
+++ b/gcpdiag/lint/gke/bp_2023_001_network_policy_minimum_requirements.py
@@ -14,7 +14,7 @@
 """GKE network policy minimum requirements
 
 The recommended minimum cluster size to run network policy enforcement is three e2-medium
-instances to ensure redundency, high availibilty and to avoid down time due to maintanence
+instances to ensure redundancy, high availability and to avoid down time due to maintenance
 activities.
 
 Network policy is not supported for clusters whose nodes are f1-micro or g1-small instances,
@@ -33,7 +33,7 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
     report.add_skipped(None, 'no clusters found')
 
   for _, c in sorted(clusters.items()):
-    # Skipping check for autopilot clusters as begining from version 1.22.7-gke.1500
+    # Skipping check for autopilot clusters as beginning from version 1.22.7-gke.1500
     # and later and versions 1.23.4-gke.1500 and later have Dataplane V2 enabled by default
 
     # Check if cluster has dataplane V2 which has network ploicy enabled

--- a/gcpdiag/lint/gke/err_2021_006_scaleup_failed.py
+++ b/gcpdiag/lint/gke/err_2021_006_scaleup_failed.py
@@ -14,7 +14,7 @@
 """GKE Autoscaler isn't reporting scaleup failures.
 
 If the GKE autoscaler reported a problem when trying to add nodes to a cluster,
-it could mean that you don't have enough resources to accomodate for new nodes.
+it could mean that you don't have enough resources to accommodate for new nodes.
 E.g. you might not have enough free IP addresses in the GKE cluster network.
 """
 

--- a/gcpdiag/lint/gke/err_2023_006_gw_controller_annotation_error.py
+++ b/gcpdiag/lint/gke/err_2023_006_gw_controller_annotation_error.py
@@ -14,7 +14,7 @@
 """GKE Gateway controller reporting misconfigured annnotations in Gateway resource
 
 Gateway controller creates loadbalancing resources based on annotations
-specified in gateway resouces. It expects the user to use correct set of
+specified in gateway resources. It expects the user to use correct set of
 supported annotations name and values.
 """
 

--- a/gcpdiag/lint/gke/snapshots/WARN_2022_001.txt
+++ b/gcpdiag/lint/gke/snapshots/WARN_2022_001.txt
@@ -7,7 +7,7 @@
    - gcpdiag-gke1-aaaa/europe-west4-a/gke4                                [FAIL]
    - gcpdiag-gke1-aaaa/europe-west4-a/gke6                                [ OK ]
 
-   Workload Identity is higly dependent of the availability of the cluster
+   Workload Identity is highly dependent of the availability of the cluster
    control plane during token fetches. It is recommended to use regional
    clusters for the production workload with Workload Identity enabled.
 

--- a/gcpdiag/lint/gke/warn_2022_001_wi_with_regional_cluster.py
+++ b/gcpdiag/lint/gke/warn_2022_001_wi_with_regional_cluster.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """GKE clusters with workload identity are regional.
 
-Workload Identity is higly dependent of the availability of the cluster control
+Workload Identity is highly dependent of the availability of the cluster control
 plane during token fetches. It is recommended to use regional clusters for the
 production workload with Workload Identity enabled.
 """

--- a/gcpdiag/lint/interconnect/snapshots/WARN_2023_003.txt
+++ b/gcpdiag/lint/interconnect/snapshots/WARN_2023_003.txt
@@ -6,7 +6,7 @@
    - gcpdiag-gke1-aaaa/dummy-interconnect4                                [ OK ]
    - gcpdiag-gke1-aaaa/dummy-interconnect5                                [FAIL]  this Interconnect link is currently under maintenance
 
-   Pleaes check the email sent to the technical contacts for further details
+   Please check the email sent to the technical contacts for further details
    about the maintenance.
 
    https://gcpdiag.dev/rules/interconnect/WARN/2023_003

--- a/gcpdiag/lint/interconnect/warn_2023_003_link_maintenance.py
+++ b/gcpdiag/lint/interconnect/warn_2023_003_link_maintenance.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """The interconnect link is undergoing a maintenance window.
 
-Pleaes check the email sent to the technical contacts for further details about the maintenance.
+Please check the email sent to the technical contacts for further details about the maintenance.
 
 """
 

--- a/gcpdiag/lint/notebooks/err_2023_003_create_notebook_permissions_missing.py
+++ b/gcpdiag/lint/notebooks/err_2023_003_create_notebook_permissions_missing.py
@@ -97,6 +97,6 @@ def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
         ('Missing permissions: '
          '@gcp-sa-notebooks.iam.gserviceaccount.com Service Account must '
          'have "AI Platform Notebooks Service Agent" role and user account '
-         'must have "Service Acount User" role'))
+         'must have "Service Account User" role'))
   else:
     report.add_ok(project)

--- a/gcpdiag/lint/notebooks/snapshots/WARN_2023_002.txt
+++ b/gcpdiag/lint/notebooks/snapshots/WARN_2023_002.txt
@@ -1,4 +1,4 @@
-*  notebooks/WARN/2023_002: Vertex AI Workbench instance is in healty data disk space status
+*  notebooks/WARN/2023_002: Vertex AI Workbench instance is in healthy data disk space status
    - gcpdiag-notebooks1-aaaa/us-west1-a/gcpdiag-notebooks1instance-aaaa   [SKIP]
      No health info found
 

--- a/gcpdiag/lint/notebooks/snapshots/WARN_2023_003.txt
+++ b/gcpdiag/lint/notebooks/snapshots/WARN_2023_003.txt
@@ -1,4 +1,4 @@
-*  notebooks/WARN/2023_003: Vertex AI Workbench instance is in healty boot disk space status
+*  notebooks/WARN/2023_003: Vertex AI Workbench instance is in healthy boot disk space status
    - gcpdiag-notebooks1-aaaa/us-west1-a/gcpdiag-notebooks1instance-aaaa   [SKIP]
      No health info found
 

--- a/gcpdiag/lint/notebooks/warn_2023_002_data_disk_utilization.py
+++ b/gcpdiag/lint/notebooks/warn_2023_002_data_disk_utilization.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Vertex AI Workbench instance is in healty data disk space status
+"""Vertex AI Workbench instance is in healthy data disk space status
 
 The data disk space status is unhealthy if the disk space is greater than 85%
 full.

--- a/gcpdiag/lint/notebooks/warn_2023_003_boot_disk_utilization.py
+++ b/gcpdiag/lint/notebooks/warn_2023_003_boot_disk_utilization.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Vertex AI Workbench instance is in healty boot disk space status
+"""Vertex AI Workbench instance is in healthy boot disk space status
 
 The boot disk space status is unhealthy if the disk space is greater than 85%
 full.

--- a/gcpdiag/lint/vpc/bp_2023_001_public_zone_logging.py
+++ b/gcpdiag/lint/vpc/bp_2023_001_public_zone_logging.py
@@ -1,6 +1,6 @@
 """DNS logging is enabled for public zones.
 
-If not enabled, customers wouldn't have visbility to what queries are being made to the zone.
+If not enabled, customers wouldn't have visibility to what queries are being made to the zone.
 """
 
 from gcpdiag import lint, models

--- a/gcpdiag/queries/cloudsql.py
+++ b/gcpdiag/queries/cloudsql.py
@@ -23,7 +23,7 @@ from gcpdiag.queries import apis, network
 
 
 class Instance(models.Resource):
-  """ Represents CloudSQL Instnace"""
+  """ Represents CloudSQL Instance"""
   _resource_data: dict
 
   def __init__(self, project_id: str, resource_data: dict):

--- a/gcpdiag/queries/gce.py
+++ b/gcpdiag/queries/gce.py
@@ -233,7 +233,7 @@ class ManagedInstanceGroup(models.Resource):
 
 
 class SerialPortOutput:
-  """Represents the full Serial Port Ouput (/dev/ttyS0 or COM1) of an instance.
+  """Represents the full Serial Port Output (/dev/ttyS0 or COM1) of an instance.
   contents is the full 1MB of the instance.
   """
   _project_id: str
@@ -1018,7 +1018,7 @@ jobs_todo: Dict[models.Context, _SerialOutputJob] = {}
 def execute_fetch_serial_port_outputs(executor: concurrent.futures.Executor):
   # start a thread to fetch serial log; processing logs can be large
   # depending on he number of instances in the project which aren't logging to cloud logging
-  # currently expects only one job but implementing it so support for multple projects is possible.
+  # currently expects only one job but implementing it so support for multiple projects is possible.
   global jobs_todo
   jobs_executing = jobs_todo
   jobs_todo = {}

--- a/gcpdiag/queries/iam.py
+++ b/gcpdiag/queries/iam.py
@@ -590,7 +590,7 @@ def _extract_project_id(email: str):
   elif email.partition('@')[2] in SERVICE_AGENT_DOMAINS or \
       email.partition('@')[2].startswith('gcp-sa-') or \
       email.endswith(DEFAULT_SERVICE_ACCOUNT_DOMAINS[1]):
-    # AppEngine Default SA is unqiue
+    # AppEngine Default SA is unique
     if email.endswith(DEFAULT_SERVICE_ACCOUNT_DOMAINS[0]):
       return email.partition('@')[0]
 

--- a/gcpdiag/queries/kubectl.py
+++ b/gcpdiag/queries/kubectl.py
@@ -108,7 +108,7 @@ class KubectlExecutor:
 def verify_auth(executor: KubectlExecutor) -> bool:
   """ Verify the authentication for kubernetes by running kubeclt cluster-info.
 
-  Will raise a warning and return False if authenticaiton failed.
+  Will raise a warning and return False if authentication failed.
   """
   _, stderr = executor.kubectl_execute([
       'kubectl', 'cluster-info', '--kubeconfig', config_path, '--context',

--- a/gcpdiag/queries/network.py
+++ b/gcpdiag/queries/network.py
@@ -921,7 +921,7 @@ class EffectiveFirewalls:
       name: Optional[str] = None,
       name_pattern: Optional[re.Pattern] = None,
       target_tags: Optional[List[str]] = None) -> List[VpcFirewallRule]:
-    """Retrive the list of ingress firewall rules matching name or name pattern and target tags.
+    """Retrieve the list of ingress firewall rules matching name or name pattern and target tags.
 
     Args:
         name (Optional[str], optional): firewall rune name. Defaults to None.
@@ -941,7 +941,7 @@ class EffectiveFirewalls:
       name: Optional[str] = None,
       name_pattern: Optional[re.Pattern] = None,
       target_tags: Optional[List[str]] = None) -> List[VpcFirewallRule]:
-    """Retrive the list of egress firewall rules matching name or name pattern and target tags.
+    """Retrieve the list of egress firewall rules matching name or name pattern and target tags.
 
     Args:
         name (Optional[str], optional): firewall rune name. Defaults to None.

--- a/gcpdiag/queries/orgpolicy.py
+++ b/gcpdiag/queries/orgpolicy.py
@@ -68,7 +68,7 @@ def _get_effective_org_policy_all_constraints(
   logging.info('getting org constraints of %s', project_id)
   for _, result, exception in apis_utils.batch_execute_all(crm_api, requests):
     if exception:
-      logging.warning("can't retrieve org contraint (error: %s)", exception)
+      logging.warning("can't retrieve org constraint (error: %s)", exception)
       continue
     if 'booleanPolicy' in result:
       all_constraints[result['constraint']] = BooleanPolicyConstraint(

--- a/gcpdiag/utils.py
+++ b/gcpdiag/utils.py
@@ -109,7 +109,7 @@ class GcpApiError(Exception):
     except KeyError:
       return None
 
-  def __init__(self, response='An error occured during the GCP API call'):
+  def __init__(self, response='An error occurred during the GCP API call'):
     self.response = response
     self.reason = None
     self.service = None

--- a/test-data/gcb1/README.md
+++ b/test-data/gcb1/README.md
@@ -11,5 +11,5 @@ important that running builds happens only once.
 
 If you want to add some data to build history, and you need to retry build
 several times to get desired outcome, then after you got to desired effect
-either run `terraform destroy` and initialize a new project or manualy remove
+either run `terraform destroy` and initialize a new project or manually remove
 older builds from json dump.

--- a/website/assets/scss/_variables_project.scss
+++ b/website/assets/scss/_variables_project.scss
@@ -62,7 +62,7 @@ img#gcpdiag-demo-cover {
   object-fit: none;
   /* will not be resized */
   object-position: 0 0;
-  /* clip to your coordonates*/
+  /* clip to your coordinates*/
   width: 550px;
   height: 260px;
   border-radius: 5px;

--- a/website/content/en/docs/authentication.md
+++ b/website/content/en/docs/authentication.md
@@ -27,7 +27,7 @@ following roles granted (both of them):
 
 - `Viewer` on the inspected project
 - `Service Usage Consumer` on the project used for billing/quota enforcement,
-  which is per default the project being inspected, but can be explicitely set
+  which is per default the project being inspected, but can be explicitly set
   using the `--billing-project` option
 
 The Editor and Owner roles include all the required permissions, but we

--- a/website/content/en/docs/running.md
+++ b/website/content/en/docs/running.md
@@ -17,7 +17,7 @@ following roles granted (both of them):
 
 - `Viewer` on the inspected project
 - `Service Usage Consumer` on the project used for billing/quota enforcement,
-  which is per default the project being inspected, but can be explicitely set
+  which is per default the project being inspected, but can be explicitly set
   using the `--billing-project` option
 
 The Editor and Owner roles include all the required permissions, but we

--- a/website/content/en/rules/apigee/ERR/2023_005.md
+++ b/website/content/en/rules/apigee/ERR/2023_005.md
@@ -29,7 +29,7 @@ Ensure that the following firewall rules are present on the project:
 
 Recreation Steps :
 
-- Identify the Managed Instace Group name and list out the configuration for it.
+- Identify the Managed Instance Group name and list out the configuration for it.
 
    `gcloud compute instance-templates describe {INSTANCE_NAME}`
 

--- a/website/content/en/rules/bigquery/ERR/2023_003.md
+++ b/website/content/en/rules/bigquery/ERR/2023_003.md
@@ -12,7 +12,7 @@ description: >
 
 ### Description
 
-A BigQuery query sometimes could not be executed in the alloted memory
+A BigQuery query sometimes could not be executed in the allotted memory
 
 ```
 resource.type="bigquery_resource"

--- a/website/content/en/rules/bigquery/WARN/2022_002.md
+++ b/website/content/en/rules/bigquery/WARN/2022_002.md
@@ -19,7 +19,7 @@ query time, whether a user has proper access.
 ### Remediation
 
 The Data Catalog Fine-Grained Reader role is required for users who need access
-to data in secured columns. You can find who voilates the access permission by
+to data in secured columns. You can find who violates the access permission by
 taking a look the "authenticationInfo" from Cloud Logging and grant proper role
 to the user if needed.
 

--- a/website/content/en/rules/cloudsql/BP_EXT/2023_003.md
+++ b/website/content/en/rules/cloudsql/BP_EXT/2023_003.md
@@ -12,7 +12,7 @@ description: >
 
 ### Description
 
-Configure storage to accomodate critical database maintennance by enabling the
+Configure storage to accommodate critical database maintennance by enabling the
 automatic storage increases feature. Otherwise, ensure that you have at least
 20% available space to accommodate any critical database maintenance operations
 that Cloud SQL may perform. Keep in mind that when an instance becomes unable to

--- a/website/content/en/rules/composer/ERR/2023_001.md
+++ b/website/content/en/rules/composer/ERR/2023_001.md
@@ -14,7 +14,7 @@ description: >
 
 The ERROR state indicates that the environment has encountered an error and
 cannot be used. Creating/updateing environment through misconfigured Terraform
-config, errors in PyPI Pacakge or etc could be the cause of the issue.
+config, errors in PyPI Package or etc could be the cause of the issue.
 
 ### Remediation
 

--- a/website/content/en/rules/composer/WARN/2022_002.md
+++ b/website/content/en/rules/composer/WARN/2022_002.md
@@ -4,7 +4,7 @@ linkTitle: "WARN/2022_002"
 weight: 1
 type: docs
 description: >
-  fluentd pods in Composer enviroments are not crashing
+  fluentd pods in Composer environments are not crashing
 ---
 
 **Product**: [Cloud Composer](https://cloud.google.com/composer)\

--- a/website/content/en/rules/dataflow/ERR/2023_006.md
+++ b/website/content/en/rules/dataflow/ERR/2023_006.md
@@ -12,7 +12,7 @@ description: >
 
 ### Description
 
-Dataflow job fails if Private Google Access is disabled on the Subnetwork used by the job, which is required when Dataflow workers only use Private addressess. Private Google Access allows workers to connect to external Google Api's and Services.
+Dataflow job fails if Private Google Access is disabled on the Subnetwork used by the job, which is required when Dataflow workers only use Private addresses. Private Google Access allows workers to connect to external Google Api's and Services.
 
 You can search in the Logs Explorer with the logging query:
 ```

--- a/website/content/en/rules/datafusion/ERR/2022_001.md
+++ b/website/content/en/rules/datafusion/ERR/2022_001.md
@@ -21,14 +21,14 @@ communicate to the Dataproc running pipeline jobs in the client project.
 ### Remediation
 
 - If your Cloud Data Fusion is private, create the [allow-ssh firewall rule](https://cloud.google.com/data-fusion/docs/how-to/create-private-ip#create_a_firewall_rule)
-with a high priority (e.g `--priority=100`) to overide any conflicting
+with a high priority (e.g `--priority=100`) to override any conflicting
 firewall rules that may be blocking communication.
 
 - If your Cloud Data Fusion is public and has a version below 6.2.0
 create the [Default allow ssh firewall rule](https://cloud.google.com/data-fusion/docs/concepts/networking#firewall-rules) with a high priority (e.g `--priority=100`)
-to overide any conflicting firewall rules that may be blocking communication.
+to override any conflicting firewall rules that may be blocking communication.
 
 ### Further information
 
-- You can find the firewall version disclamer
+- You can find the firewall version disclaimer
 in the `Creating a Cloud Data Fusion instance` [Before you begin](https://cloud.google.com/data-fusion/docs/how-to/create-instance#before_you_begin) section.

--- a/website/content/en/rules/dataproc/ERR/2023_007.md
+++ b/website/content/en/rules/dataproc/ERR/2023_007.md
@@ -4,7 +4,7 @@ linkTitle: "ERR/2023_007"
 weight: 1
 type: docs
 description: >
-  Region has sufficent resources for user to create a cluster
+  Region has sufficient resources for user to create a cluster
 ---
 
 **Product**: [Cloud Dataproc](https://cloud.google.com/dataproc)\

--- a/website/content/en/rules/gce/WARN/2021_006.md
+++ b/website/content/en/rules/gce/WARN/2021_006.md
@@ -13,11 +13,11 @@ description: >
 ### Description
 
 The "Kernel panic" messages in serial output usually indicate that some
-fatal error occured on a Linux instance.
+fatal error occurred on a Linux instance.
 
 ### Remediation
 
-This issue requires futher troubleshooting as root causes vary in this case.
+This issue requires further troubleshooting as root causes vary in this case.
 Some common issues that could cause kernel to panic:
 - Memory pressure
 - Disk pressure

--- a/website/content/en/rules/gce/WARN/2021_007.md
+++ b/website/content/en/rules/gce/WARN/2021_007.md
@@ -14,11 +14,11 @@ description: >
 
 The messages:
 "Dumping stack trace" / "pvpanic.sys" in serial output usually indicate that some
-fatal error occured on a Windows instance.
+fatal error occurred on a Windows instance.
 
 ### Remediation
 
-This issue requires futher troubleshooting as root causes vary in this case.
+This issue requires further troubleshooting as root causes vary in this case.
 Some common issues that could cause BSODs:
 - Memory pressure
 - Disk pressure

--- a/website/content/en/rules/gce/WARN/2022_010.md
+++ b/website/content/en/rules/gce/WARN/2022_010.md
@@ -12,7 +12,7 @@ description: >
 
 ### Description
 
-Resource availablity errors can occur when using GCE resource on demand and a
+Resource availability errors can occur when using GCE resource on demand and a
 zone cannot accommodate your request due to resource exhaustion for the
 specific VM configuration. Consider trying your request in other zones,
 requesting again with a different VM hardware configuration or at a later

--- a/website/content/en/rules/gke/BP_EXT/2022_001.md
+++ b/website/content/en/rules/gke/BP_EXT/2022_001.md
@@ -16,7 +16,7 @@ User access should be managed with Google Groups so Workspace administrators can
 
 ### Remediation
 
-Follow the documention for steps on [How to enable Google Groups for RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac#enable) on GKE clusters.
+Follow the documentation for steps on [How to enable Google Groups for RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac#enable) on GKE clusters.
 
 ### Further information
 

--- a/website/content/en/rules/gke/ERR/2021_006.md
+++ b/website/content/en/rules/gke/ERR/2021_006.md
@@ -13,7 +13,7 @@ description: >
 ### Description
 
 If the GKE autoscaler reported a problem when trying to add nodes to a cluster,
-it could mean that you don't have enough resources to accomodate for new nodes.
+it could mean that you don't have enough resources to accommodate for new nodes.
 E.g. you might not have enough free IP addresses in the GKE cluster network.
 
 ### Remediation

--- a/website/content/en/rules/gke/ERR/2023_003.md
+++ b/website/content/en/rules/gke/ERR/2023_003.md
@@ -24,7 +24,7 @@ The config file in question is `/etc/containerd/config.toml`.
 Usually such a change is introduced via a DaemonSet with a privileged
 container.
 
-A short-term remidiation is to disable (delete) the DeamonSet and
+A short-term remidiation is to disable (delete) the DaemonSet and
 recreate all affected nodes by scaling the affected nodepools to 0 nodes and
 then back, to the original value.
 
@@ -33,8 +33,8 @@ DaemonSet).
 
 One of the known DaemonSets that could cause
 this issue is `twistlock defender` from [Prizma Cloud security suite](https://docs.paloaltonetworks.com/prisma/prisma-cloud),
-which could inject configuration entries in old configuraton file format to a
-configuration file created with a newer configuraton file format.
+which could inject configuration entries in old configuration file format to a
+configuration file created with a newer configuration file format.
 
 You can use the following filter to find matching log lines:
 

--- a/website/content/en/rules/gke/ERR/2023_006.md
+++ b/website/content/en/rules/gke/ERR/2023_006.md
@@ -13,7 +13,7 @@ description: >
 ### Description
 
 Gateway controller creates loadbalancing resources based on annotations
-specified in gateway resouces.
+specified in gateway resources.
 
 It expects the user to use correct set of supported annotations name and values.
 
@@ -29,6 +29,6 @@ resource.type="k8s_cluster"
 
 ### Remediation
 
-- Fix the annotaions in gateway resources obtained from above query
+- Fix the annotations in gateway resources obtained from above query
 
 ### Further information

--- a/website/content/en/rules/gke/WARN/2022_001.md
+++ b/website/content/en/rules/gke/WARN/2022_001.md
@@ -12,7 +12,7 @@ description: >
 
 ### Description
 
-Workload Identity is higly dependent of the availability of the cluster control
+Workload Identity is highly dependent of the availability of the cluster control
 plane during token fetches. It is recommended to use regional clusters for the
 production workload with Workload Identity enabled.
 

--- a/website/content/en/rules/gke/WARN/2022_005.md
+++ b/website/content/en/rules/gke/WARN/2022_005.md
@@ -12,7 +12,7 @@ description: >
 
 ### Description
 
-After adding GPU nodes to the GKE cluster, the NVIDIA's device drivers should be installed in the nodes. Google provides a DaemonSet that will install for the drivers. This rule detectes that if the `nvidia-driver-installer` DaemonSet is missing using the `kubernetes.io/container/uptime` metric.
+After adding GPU nodes to the GKE cluster, the NVIDIA's device drivers should be installed in the nodes. Google provides a DaemonSet that will install for the drivers. This rule detects that if the `nvidia-driver-installer` DaemonSet is missing using the `kubernetes.io/container/uptime` metric.
 
 ### Remediation
 

--- a/website/content/en/rules/notebooks/BP/2023_002.md
+++ b/website/content/en/rules/notebooks/BP/2023_002.md
@@ -28,4 +28,4 @@ There are two ways to upgrade a user-managed notebooks instance:
 
 ### Further information
 
-- [Upgrade the enviroment of a user-managed notebook instance](https://cloud.google.com/vertex-ai/docs/workbench/user-managed/upgrade)
+- [Upgrade the environment of a user-managed notebook instance](https://cloud.google.com/vertex-ai/docs/workbench/user-managed/upgrade)

--- a/website/content/en/rules/notebooks/BP/2023_003.md
+++ b/website/content/en/rules/notebooks/BP/2023_003.md
@@ -25,4 +25,4 @@ notebooks instance that you want to upgrade.
 
 ### Further information
 
-- [Upgrade the enviroment of a managed notebooks instance](https://cloud.google.com/vertex-ai/docs/workbench/managed/upgrade)
+- [Upgrade the environment of a managed notebooks instance](https://cloud.google.com/vertex-ai/docs/workbench/managed/upgrade)

--- a/website/content/en/rules/notebooks/BP/2023_004.md
+++ b/website/content/en/rules/notebooks/BP/2023_004.md
@@ -17,7 +17,7 @@ after being idle for a specific time period. You can change the amount of time.
 
 ### Remediation
 
-Go to the `SOFTWARE AND SECURITY` tab and mark the `Enable Idle Shutodwn`
+Go to the `SOFTWARE AND SECURITY` tab and mark the `Enable Idle Shutdown`
 checkbox.
 
 ### Further information

--- a/website/content/en/rules/notebooks/WARN/2023_002.md
+++ b/website/content/en/rules/notebooks/WARN/2023_002.md
@@ -4,7 +4,7 @@ linkTitle: "WARN/2023_002"
 weight: 1
 type: docs
 description: >
-  Vertex AI Workbench instance is in healty data disk space status
+  Vertex AI Workbench instance is in healthy data disk space status
 ---
 
 **Product**: [Vertex AI Workbench](https://cloud.google.com/vertex-ai-workbench)\

--- a/website/content/en/rules/notebooks/WARN/2023_003.md
+++ b/website/content/en/rules/notebooks/WARN/2023_003.md
@@ -4,7 +4,7 @@ linkTitle: "WARN/2023_003"
 weight: 1
 type: docs
 description: >
-  Vertex AI Workbench instance is in healty boot disk space status
+  Vertex AI Workbench instance is in healthy boot disk space status
 ---
 
 **Product**: [Vertex AI Workbench](https://cloud.google.com/vertex-ai-workbench)\

--- a/website/content/en/rules/vpc/BP/2023_001.md
+++ b/website/content/en/rules/vpc/BP/2023_001.md
@@ -12,7 +12,7 @@ description: >
 
 ### Description
 
-If not enabled, customers wouldn't have visbility to what queries are being made to the zone.
+If not enabled, customers wouldn't have visibility to what queries are being made to the zone.
 
 ### Remediation
 


### PR DESCRIPTION
Updating working and typos in multiple files:

- .devcontainer/devcontainer.json
- .pylintrc
- bin/gcpdiag-dockerized
- CHANGELOG.md
- gcpdiag/async_queries/api/default_random.py
- gcpdiag/async_queries/api/test_webserver.py
- gcpdiag/async_queries/dataproc/dataproc.py
- gcpdiag/async_queries/project/project.py
- gcpdiag/async_queries/utils/loader.py
- gcpdiag/config_test.py
- gcpdiag/lint/__init__.py
- gcpdiag/lint/bigquery/err_2023_003_resource_exceeded.py
- gcpdiag/lint/command.py
- gcpdiag/lint/composer/err_2023_001_composer_not_in_error_state.py
- gcpdiag/lint/composer/snapshots/WARN_2022_002.txt
- gcpdiag/lint/composer/warn_2022_002_fluentd_pod_crashloop.py
- gcpdiag/lint/dataproc/err_2023_007_cluster_creation_stockout.py
- gcpdiag/lint/dataproc/snapshots/ERR_2023_007.txt
- gcpdiag/lint/gae/err_2023_002_appengine_vpc_connector_subnet_overlap.py
- gcpdiag/lint/gce/bp_2023_001_ntp_config.py
- gcpdiag/lint/gce/err_2021_005_mount_errors.py
- gcpdiag/lint/gce/err_2022_002_premium_guestos_activation_failed.py
- gcpdiag/lint/gce/warn_2021_004_disk_full_serial_messages.py
- gcpdiag/lint/gce/warn_2021_005_out_of_memory.py
- gcpdiag/lint/gce/warn_2021_006_kernel_panic.py
- gcpdiag/lint/gce/warn_2021_007_bsod.py
- gcpdiag/lint/gce/warn_2022_010_resource_availability.py
- gcpdiag/lint/gke/bp_2023_001_network_policy_minimum_requirements.py
- gcpdiag/lint/gke/err_2021_006_scaleup_failed.py
- gcpdiag/lint/gke/err_2023_006_gw_controller_annotation_error.py
- gcpdiag/lint/gke/snapshots/WARN_2022_001.txt
- gcpdiag/lint/gke/warn_2022_001_wi_with_regional_cluster.py
- gcpdiag/lint/interconnect/snapshots/WARN_2023_003.txt
- gcpdiag/lint/interconnect/warn_2023_003_link_maintenance.py
- gcpdiag/lint/notebooks/err_2023_003_create_notebook_permissions_missing.py
- gcpdiag/lint/notebooks/snapshots/WARN_2023_002.txt
- gcpdiag/lint/notebooks/snapshots/WARN_2023_003.txt
- gcpdiag/lint/notebooks/warn_2023_002_data_disk_utilization.py
- gcpdiag/lint/notebooks/warn_2023_003_boot_disk_utilization.py
- gcpdiag/lint/vpc/bp_2023_001_public_zone_logging.py
- gcpdiag/queries/cloudsql.py
- gcpdiag/queries/gce.py
- gcpdiag/queries/iam.py
- gcpdiag/queries/kubectl.py
- gcpdiag/queries/network.py
- gcpdiag/queries/orgpolicy.py
- gcpdiag/utils.py
- README.md
- test-data/gcb1/README.md
- website/assets/scss/_variables_project.scss
- website/content/en/docs/authentication.md
- website/content/en/docs/running.md
- website/content/en/rules/apigee/ERR/2023_005.md
- website/content/en/rules/bigquery/ERR/2023_003.md
- website/content/en/rules/bigquery/WARN/2022_002.md
- website/content/en/rules/cloudsql/BP_EXT/2023_003.md
- website/content/en/rules/composer/ERR/2023_001.md
- website/content/en/rules/composer/WARN/2022_002.md
- website/content/en/rules/dataflow/ERR/2023_006.md
- website/content/en/rules/datafusion/ERR/2022_001.md
- website/content/en/rules/dataproc/ERR/2023_007.md
- website/content/en/rules/gce/WARN/2021_006.md
- website/content/en/rules/gce/WARN/2021_007.md
- website/content/en/rules/gce/WARN/2022_010.md
- website/content/en/rules/gke/BP_EXT/2022_001.md
- website/content/en/rules/gke/ERR/2021_006.md
- website/content/en/rules/gke/ERR/2023_003.md
- website/content/en/rules/gke/ERR/2023_006.md
- website/content/en/rules/gke/WARN/2022_001.md
- website/content/en/rules/gke/WARN/2022_005.md
- website/content/en/rules/notebooks/BP/2023_002.md
- website/content/en/rules/notebooks/BP/2023_003.md
- website/content/en/rules/notebooks/BP/2023_004.md
- website/content/en/rules/notebooks/WARN/2023_002.md
- website/content/en/rules/notebooks/WARN/2023_003.md
- website/content/en/rules/vpc/BP/2023_001.md