### PR TITLE
Add the id label to filter the Dataflow jobs using the job id

### DIFF
--- a/gcpdiag/lint/gke/eol.yaml
+++ b/gcpdiag/lint/gke/eol.yaml
@@ -27,15 +27,15 @@
 '1.28':
   oss_release: 2023-08-15
   rapid_avail: 2023-09-05
-  regular_avail: 2023-12
-  stable_avail: 2024-Q1
-  eol: TBD
+  regular_avail: 2023-12-04
+  stable_avail: 2024-01
+  eol: 2024-11-12
 '1.29':
-  oss_release: TBD
-  rapid_avail: TBD
-  regular_avail: TBD
-  stable_avail: TBD
-  eol: TBD
+  oss_release: 2023-12-13
+  rapid_avail: 2024-01-12
+  regular_avail: 2024-01
+  stable_avail: 2024-Q1
+  eol: 2025-03-21
 '1.30':
   oss_release: TBD
   rapid_avail: TBD

--- a/gcpdiag/queries/dataflow.py
+++ b/gcpdiag/queries/dataflow.py
@@ -90,8 +90,8 @@ def get_all_dataflow_jobs(context: models.Context) -> List[Job]:
 
   print(f'\n\nFound {len(result)} Dataflow jobs\n')
 
-  # only print one job id
-  if len(result) == 1:
+  # print one Dataflow job id when it is found
+  if context.labels and result and 'id' in context.labels:
     print(f'{result[0].full_path} - {result[0].id}\n')
 
   return result

--- a/gcpdiag/queries/dataflow.py
+++ b/gcpdiag/queries/dataflow.py
@@ -62,6 +62,9 @@ def get_region_dataflow_jobs(api, context: models.Context,
     labels = job.get('labels', {})
     name = job.get('name', '')
 
+    # add job id as one of labels for filtering
+    labels['id'] = job.get('id', '')
+
     # we could get the specific job but correctly matching the location will take too
     # much effort. Hence get all the jobs and filter afterwards
     # https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs/list#query-parameters
@@ -84,4 +87,11 @@ def get_all_dataflow_jobs(context: models.Context) -> List[Job]:
   for jobs in executor.map(lambda r: get_region_dataflow_jobs(api, context, r),
                            DATAFLOW_REGIONS):
     result += jobs
+
+  print(f'\n\nFound {len(result)} Dataflow jobs\n')
+
+  # only print one job id
+  if len(result) == 1:
+    print(f'{result[0].full_path} - {result[0].id}\n')
+
   return result

--- a/gcpdiag/queries/dataflow_test.py
+++ b/gcpdiag/queries/dataflow_test.py
@@ -17,3 +17,11 @@ class TestDataFlow:
     jobs = dataflow.get_all_dataflow_jobs(context)
     assert {j.state for j in jobs} == {'JOB_STATE_DONE'}
     assert None not in [j.minutes_in_current_state for j in jobs]
+
+  def test_get_jobs_with_id(self):
+    context = models.Context(
+        project_id=DUMMY_PROJECT_NAME,
+        labels={'id': '2022-09-19_09_20_57-11848816011797209899'})
+    jobs = dataflow.get_all_dataflow_jobs(context)
+    assert len(jobs) == 1
+    assert jobs[0].id == '2022-09-19_09_20_57-11848816011797209899'


### PR DESCRIPTION
It is very common that the Dataflow users run thousands of Dataflow jobs. Diagnosing all of them is quite meaningless. Here we support using the label id as a way to filter the Dataflow jobs to the desired one and the example is:
```bash
bin/gcpdiag lint --project your_gcp_project --include dataflow --label id:2023-12-27_13_00_01-4471608447580374632
```
  