### PR TITLE
Add rule for `container.defaultNodeServiceAccount` permission check

### DIFF
--- a/gcpdiag/lint/gke/err_2024_003_default_node_serviceaccount_perm.py
+++ b/gcpdiag/lint/gke/err_2024_003_default_node_serviceaccount_perm.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GKE nodes service account permissions fit container.defaultNodeServiceAccount role
+
+The service account used by GKE nodes should possess the permissions of the
+container.defaultNodeServiceAccount role, otherwise ingestion of logs or metrics
+won't work.
+"""
+
+from gcpdiag import lint, models
+from gcpdiag.queries import gke, iam
+
+ROLE = 'roles/container.defaultNodeServiceAccount'
+
+
+def prefetch_rule(context: models.Context):
+  # Make sure that we have the IAM policy in cache.
+  project_ids = {c.project_id for c in gke.get_clusters(context).values()}
+  for pid in project_ids:
+    iam.get_project_policy(pid)
+
+
+def run_rule(context: models.Context, report: lint.LintReportRuleInterface):
+  # Find all clusters with logging and metrics enabled.
+  clusters = gke.get_clusters(context)
+  iam_policy = iam.get_project_policy(context.project_id)
+  if not clusters:
+    report.add_skipped(None, 'no clusters found')
+  for _, c in sorted(clusters.items()):
+    if not c.has_logging_enabled():
+      report.add_skipped(c, 'logging disabled')
+    elif not c.has_monitoring_enabled():
+      report.add_skipped(c, 'monitoring disabled')
+    else:
+      # Verify service-account permissions for every nodepool.
+      for np in c.nodepools:
+        sa = np.service_account
+        if not iam_policy.has_role_permissions(f'serviceAccount:{sa}', ROLE):
+          report.add_failed(np, f'service account: {sa}\nmissing role: {ROLE}')
+        else:
+          report.add_ok(np)

--- a/gcpdiag/lint/gke/snapshots/ERR_2024_003.txt
+++ b/gcpdiag/lint/gke/snapshots/ERR_2024_003.txt
@@ -1,0 +1,17 @@
+*  gke/ERR/2024_003: GKE nodes service account permissions fit container.defaultNodeServiceAccount role
+   - projects/gcpdiag-gke1-aaaa/locations/europe-west4/clusters/gke2/nodePools/default-pool [ OK ]
+   - projects/gcpdiag-gke1-aaaa/locations/europe-west4/clusters/gke2/nodePools/low-pod-per-node-pool [ OK ]
+   - projects/gcpdiag-gke1-aaaa/locations/europe-west4/clusters/gke3/nodePools/default-pool [FAIL]
+     service account: gke3sa@gcpdiag-gke1-aaaa.iam.gserviceaccount.com
+     missing role: roles/container.defaultNodeServiceAccount
+   - projects/gcpdiag-gke1-aaaa/zones/europe-west4-a/clusters/gke1        [SKIP]
+     logging disabled
+   - projects/gcpdiag-gke1-aaaa/zones/europe-west4-a/clusters/gke4/nodePools/default-pool [ OK ]
+   - projects/gcpdiag-gke1-aaaa/zones/europe-west4-a/clusters/gke6/nodePools/default-pool [ OK ]
+
+   The service account used by GKE nodes should possess the permissions of the
+   container.defaultNodeServiceAccount role, otherwise ingestion of logs or
+   metrics won't work.
+
+   https://gcpdiag.dev/rules/gke/ERR/2024_003
+

--- a/test-data/gke1/Makefile
+++ b/test-data/gke1/Makefile
@@ -173,10 +173,16 @@ json-dumps/iam-roles-custom.json:
 		| $(SED_SUBST_FAKE) >$@
 
 json-dumps/iam-roles-get.json:
+ 	$(CURL) -fsS \
+ 		'https://iam.googleapis.com/v1/roles/container.nodeServiceAgent' \
+ 		| $(SED_SUBST_FAKE) \
+		| jq '{"roles": [.]}' >$@.tmp
 	$(CURL) -fsS \
-		'https://iam.googleapis.com/v1/roles/container.nodeServiceAgent' \
+		'https://iam.googleapis.com/v1/roles/container.defaultNodeServiceAccount' \
 		| $(SED_SUBST_FAKE) \
-		| jq '{"roles": [.]}' >$@
+		| jq '{"roles": [.]}' >>$@.tmp
+	jq -s '. | {"roles": map(.)}' $@.tmp > $@
+	rm $@.tmp
 
 json-dumps/iam-service-accounts.json:
 	$(CURL) -fsS \

--- a/test-data/gke1/json-dumps/iam-roles-get.json
+++ b/test-data/gke1/json-dumps/iam-roles-get.json
@@ -2,7 +2,7 @@
   "roles": [
     {
       "name": "roles/container.nodeServiceAgent",
-      "title": "Kubernetes Engine Node Service Agent",
+      "title": "[Deprecated] Kubernetes Engine Node Service Agent",
       "description": "Minimal set of permission required by a GKE node to support standard capabilities such as logging and monitoring export, and image pulls.",
       "includedPermissions": [
         "autoscaling.sites.writeMetrics",
@@ -10,11 +10,29 @@
         "monitoring.metricDescriptors.create",
         "monitoring.metricDescriptors.list",
         "monitoring.timeSeries.create",
+        "monitoring.timeSeries.list",
         "resourcemanager.projects.get",
         "resourcemanager.projects.list",
+        "serviceusage.services.use",
         "storage.objects.get",
         "storage.objects.list"
       ],
+       "stage": "GA",
+       "etag": "AA=="
+     },
+     {
+       "name": "roles/container.defaultNodeServiceAccount",
+       "title": "Kubernetes Engine Default Node Service Account",
+       "description": "Least privilege role to use as the default service account for GKE Nodes.",
+       "includedPermissions": [
+         "autoscaling.sites.writeMetrics",
+         "logging.logEntries.create",
+         "monitoring.metricDescriptors.create",
+         "monitoring.metricDescriptors.list",
+         "monitoring.timeSeries.create",
+         "monitoring.timeSeries.list"
+       ],
+       "stage": "GA",
       "etag": "AA=="
     }
   ]

--- a/website/content/en/rules/gke/ERR/2024_003.md
+++ b/website/content/en/rules/gke/ERR/2024_003.md
@@ -1,0 +1,30 @@
+---
+title: "gke/ERR/2024_003"
+linkTitle: "ERR/2024_003"
+weight: 1
+type: docs
+description: >
+  GKE nodes service account permissions fit container.defaultNodeServiceAccount role
+---
+
+**Product**: [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)\
+**Rule class**: Something that is very likely to be wrong
+
+### Description
+
+The service account used by GKE nodes should possess the permissions of the container.defaultNodeServiceAccount role,
+otherwise ingestion of logs or metrics won't work.
+
+### Remediation
+
+Make sure your GKE node pool service accounts have the following role binding in the IAM policy
+
+- Principal: GKE node pool service account
+- Role: `container.defaultNodeServiceAccount`
+
+or use a custom role which
+contains [those permissions](https://cloud.google.com/iam/docs/understanding-roles#container.defaultNodeServiceAccount)
+
+### Further information
+
+- [Hardening your cluster - Use least privilege IAM service Accounts](https://cloud.google.com/linhttps://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa)


### PR DESCRIPTION
Reintroduces the changes after #109 reverted them.